### PR TITLE
Add configurable fan speed count: options flow, label, and version bump

### DIFF
--- a/custom_components/omnibreeze/__init__.py
+++ b/custom_components/omnibreeze/__init__.py
@@ -58,16 +58,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await async_mute_fans_once()
 
+    fan_speed_count = entry.options.get(
+        CONF_FAN_SPEED_COUNT,
+        entry.data.get(CONF_FAN_SPEED_COUNT, DEFAULT_FAN_SPEED_COUNT),
+    )
+
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "api": api,
         "coordinator": coordinator,
-        "fan_speed_count": entry.data.get(CONF_FAN_SPEED_COUNT, DEFAULT_FAN_SPEED_COUNT),
+        "fan_speed_count": fan_speed_count,
     }
+
+    # Reload the entry when its options change so a new speed count takes effect.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/omnibreeze/config_flow.py
+++ b/custom_components/omnibreeze/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 
 from .api import OmniBreezeApi
 from .const import (
@@ -66,6 +66,13 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class OmniBreezeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "OmniBreezeOptionsFlow":
+        return OmniBreezeOptionsFlow()
+
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         errors: dict[str, str] = {}
 
@@ -89,3 +96,25 @@ class OmniBreezeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )
+
+
+class OmniBreezeOptionsFlow(config_entries.OptionsFlow):
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(
+            CONF_FAN_SPEED_COUNT,
+            self.config_entry.data.get(CONF_FAN_SPEED_COUNT, DEFAULT_FAN_SPEED_COUNT),
+        )
+
+        options_schema = vol.Schema(
+            {
+                vol.Optional(CONF_FAN_SPEED_COUNT, default=current): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_FAN_SPEED_COUNT, max=MAX_FAN_SPEED_COUNT),
+                ),
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=options_schema)

--- a/custom_components/omnibreeze/manifest.json
+++ b/custom_components/omnibreeze/manifest.json
@@ -14,5 +14,5 @@
     "websocket-client>=1.8.0",
     "pycryptodome>=3.20.0"
   ],
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/custom_components/omnibreeze/strings.json
+++ b/custom_components/omnibreeze/strings.json
@@ -19,5 +19,16 @@
     "abort": {
       "already_configured": "This account is already configured."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "OmniBreeze options",
+        "description": "Adjust how the OmniBreeze fans are exposed in Home Assistant.",
+        "data": {
+          "fan_speed_count": "Fan speed count"
+        }
+      }
+    }
   }
 }

--- a/custom_components/omnibreeze/strings.json
+++ b/custom_components/omnibreeze/strings.json
@@ -8,7 +8,8 @@
           "email": "Email",
           "password": "Password",
           "user_domain": "User domain",
-          "user_domain_secret": "User domain secret"
+          "user_domain_secret": "User domain secret",
+          "fan_speed_count": "Fan speed count"
         }
       }
     },


### PR DESCRIPTION
Follow-up to #5/#6 (configurable fan speed count). Those merged the setup field but left a few gaps:

- Version not bumped — main was still 0.2.4, so HACS doesn't offer the update. Bumped to 0.2.5.
- No strings.json label — the new field rendered as a raw fan_speed_count key. Added "Fan speed count".
- No way to change it after setup — required removing/re-adding the integration. Added an options flow (Configure button) that reloads the entry so the new count applies immediately.